### PR TITLE
Multi splitter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,4 @@ dmypy.json
 # Manual additions to .gitignore
 .vscode/settings.json
 pdf_manager/
-Fourier Transforms.pdf
-Split PDFs/
 .DS_Store

--- a/pdf_splitter.py
+++ b/pdf_splitter.py
@@ -46,6 +46,9 @@ class PdfSplitter:
             filenames (list, optional): specify file names. Defaults to
                                         ['first_part', 'second_part'].
 
+        Returns:
+            part_one (PosixPath object): path to the part one of the split PDF.
+            part_one (PosixPath object): path to the part two of the split PDF.
         """
         if pg_num <= 1:
             raise ValueError('The input number will return the PDF '

--- a/test_pdf_splitter.py
+++ b/test_pdf_splitter.py
@@ -9,6 +9,7 @@ import pytest
 
 
 file_path = 'Fourier Transforms.pdf'
+pdf_splitter = PdfSplitter(file_path)
 
 
 def test_object_creation_1():
@@ -38,8 +39,77 @@ def test_object_creation_5():
 
 def test_single_split():
     pdf_splitter = PdfSplitter(file_path)
-    pdf_splitter.single_split(3)
-    path = pathlib.Path('Split PDFs') / 'part_2.pdf'
-    part_two = PdfFileReader(str(path))
+    p1, p2 = pdf_splitter.single_split(3)
+    part_two = PdfFileReader(str(p2))
     num_diff = pdf_splitter.pdf_file.getNumPages() - 2 - part_two.getNumPages()
     assert num_diff == 0
+
+    # Delete created files
+    p1.unlink()
+    p2.unlink()
+    p1.parent.rmdir()
+
+
+def test_multi_splitter_file_len():
+    filenames = ['Index.pdf',
+                 'Data in frequency domain.pdf',
+                 'The complex Fourier Series',
+                 'The Rest']
+    file_lens = [2, 4, 2, 18]
+
+    out = pdf_splitter.multi_split(3, 7, 9, filenames=filenames)
+    directory = out[0]
+    for num, name in zip(file_lens, filenames):
+        path = directory / name
+        part = PdfFileReader(str(path))
+        assert part.getNumPages() == num
+
+    # Delete created files
+    for path in directory.iterdir():
+        path.unlink()
+    directory.rmdir()
+
+
+def test_multi_splitter_pg_ValueError_1():
+    with pytest.raises(ValueError):
+        pdf_splitter.multi_split(-1)
+
+
+def test_multi_splitter_pg_ValueError_2():
+    with pytest.raises(ValueError):
+        pdf_splitter.multi_split(27)
+
+
+def test_multi_splitter_file_ValueError_2():
+    with pytest.raises(ValueError):
+        pdf_splitter.multi_split(filenames=['test1.pdf'])
+
+
+def test_multi_splitter_filenames():
+    directory, filenames = pdf_splitter.multi_split(3)
+    assert filenames == ['part_1.pdf', 'part_2.pdf']
+
+    # Delete created files
+    for path in directory.iterdir():
+        path.unlink()
+    directory.rmdir()
+
+
+def test_multi_splitter_dir_1():
+    directory, filenames = pdf_splitter.multi_split(3, new_dir_name='Test dir')
+    assert directory.name == 'Test dir'
+
+    # Delete created files
+    for path in directory.iterdir():
+        path.unlink()
+    directory.rmdir()
+
+
+def test_multi_splitter_dir_2():
+    directory, filenames = pdf_splitter.multi_split(3, new_dir_name='Test dir')
+    assert directory.exists()
+
+    # Delete created files
+    for path in directory.iterdir():
+        path.unlink()
+    directory.rmdir()

--- a/test_pdf_splitter.py
+++ b/test_pdf_splitter.py
@@ -5,6 +5,7 @@ from pdf_splitter import PdfSplitter
 from PyPDF2 import PdfFileReader
 import PyPDF2
 import pathlib
+import shutil
 import pytest
 
 
@@ -45,9 +46,7 @@ def test_single_split():
     assert num_diff == 0
 
     # Delete created files
-    p1.unlink()
-    p2.unlink()
-    p1.parent.rmdir()
+    shutil.rmtree(p1.parent)
 
 
 def test_multi_splitter_file_len():
@@ -65,9 +64,7 @@ def test_multi_splitter_file_len():
         assert part.getNumPages() == num
 
     # Delete created files
-    for path in directory.iterdir():
-        path.unlink()
-    directory.rmdir()
+    shutil.rmtree(directory)
 
 
 def test_multi_splitter_pg_ValueError_1():
@@ -90,9 +87,7 @@ def test_multi_splitter_filenames():
     assert filenames == ['part_1.pdf', 'part_2.pdf']
 
     # Delete created files
-    for path in directory.iterdir():
-        path.unlink()
-    directory.rmdir()
+    shutil.rmtree(directory)
 
 
 def test_multi_splitter_dir_1():
@@ -100,9 +95,7 @@ def test_multi_splitter_dir_1():
     assert directory.name == 'Test dir'
 
     # Delete created files
-    for path in directory.iterdir():
-        path.unlink()
-    directory.rmdir()
+    shutil.rmtree(directory)
 
 
 def test_multi_splitter_dir_2():
@@ -110,6 +103,4 @@ def test_multi_splitter_dir_2():
     assert directory.exists()
 
     # Delete created files
-    for path in directory.iterdir():
-        path.unlink()
-    directory.rmdir()
+    shutil.rmtree(directory)


### PR DESCRIPTION
- [x] Add multi_split method to pdf_splitter.py.
    - [x] PDF document can be split into n number of pages (max value of n = number of pages of PDF).
    - [x] Filenames for each new split can be set using an argument.
    - [x] Missing filenames are filled with default values.
    - [x] '.pdf', file extension can be added for filenames missing it.
    - [x] Save all the split PDF documents in a new directory.
    - [x] Name of the directory can be set using an argument.
    - [x] Check if page names are within range.
    - [x] Check if filenames provided are less than or equal to number of splits.
- [x] Add tests for multi_split method to test_pdf_splitter.py.